### PR TITLE
Fix Bug in BoxZones

### DIFF
--- a/res/mcmod.info
+++ b/res/mcmod.info
@@ -1,7 +1,7 @@
 [{
     "modid": "dosmike_toolbbox",
     "name": "Mike's ToolBox",
-    "version": "1.0",
+    "version": "1.0.1",
     "description": "Simplify lots of things because I can",
     "authorList": [ "DosMike" ],
 	"requiredMods": [ "spongeapi" ],

--- a/src/de/dosmike/sponge/mikestoolbox/BoxLoader.java
+++ b/src/de/dosmike/sponge/mikestoolbox/BoxLoader.java
@@ -35,7 +35,7 @@ import de.dosmike.sponge.mikestoolbox.zone.ZoneServiceProvider;
 /** <b>This is not the Package you are looking for :)</b><br>
  * The ToolBox plugin will load modules and provide base services<br>
  * Most Tools should be accessed in a static way. */
-@Plugin(id = "dosmike_toolbbox", name = "Mike's ToolBox", version = "1.0")
+@Plugin(id = "dosmike_toolbbox", name = "Mike's ToolBox", version = "1.0.1")
 public class BoxLoader {
 	/** everyone needs some random in his life */
 	public static Random RNG = new Random(System.currentTimeMillis());

--- a/src/de/dosmike/sponge/mikestoolbox/zone/MultiRangeZone.java
+++ b/src/de/dosmike/sponge/mikestoolbox/zone/MultiRangeZone.java
@@ -231,9 +231,10 @@ public class MultiRangeZone implements Zone {
 	}
 	@Override
 	public boolean isInside(Location<?> loc) {
-		if (!ranges.iterator().next().getExtent().equals(loc.getExtent())) return false;
-		for (Range r : ranges)
-			if (r.contains(loc.getPosition())) return true;
+		for (Range r : ranges) {
+			if (loc.getExtent().equals(r.getExtent().orElse(null)) &&
+				r.contains(loc.getPosition())) return true;
+		}
 		return false;
 	}
 	@Override


### PR DESCRIPTION
Fixed a bug where MultiRangeZone::inside(Location<World>) would always return false because Extent was compared to Optional<Extent>